### PR TITLE
feat: announce version 1 launch on website

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,7 @@ Yes, you can!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+
+## Release timeline
+
+- Version 1 launch: 1st September

--- a/src/components/FloatingParticles.tsx
+++ b/src/components/FloatingParticles.tsx
@@ -8,6 +8,16 @@ interface FloatingParticlesProps {
   variant?: 'default' | 'fusion' | 'fission' | 'glow';
 }
 
+interface Particle {
+  id: number;
+  x: number;
+  y: number;
+  size: number;
+  duration: number;
+  delay: number;
+  speed: number;
+}
+
 const FloatingParticles: React.FC<FloatingParticlesProps> = ({ 
   count = 20, 
   className = "",
@@ -17,7 +27,7 @@ const FloatingParticles: React.FC<FloatingParticlesProps> = ({
   const [mousePosition, setMousePosition] = useState({ x: 0, y: 0 });
   const [clickedParticles, setClickedParticles] = useState<Set<number>>(new Set());
 
-  const particles = Array.from({ length: count }, (_, i) => ({
+  const particles: Particle[] = Array.from({ length: count }, (_, i) => ({
     id: i,
     x: Math.random() * 100,
     y: Math.random() * 100,
@@ -65,7 +75,7 @@ const FloatingParticles: React.FC<FloatingParticlesProps> = ({
     }
   };
 
-  const getMouseInfluence = (particle: any) => {
+  const getMouseInfluence = (particle: Particle) => {
     if (!interactive) return { x: 0, y: 0 };
     
     const distance = Math.sqrt(

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps;
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,8 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps =
+  React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -194,8 +194,12 @@ const Index = () => {
                 Join the Network
               </Button>
             </form>
-            
-            <motion.div 
+
+            <p className="font-mono text-sm mt-12 text-muted-foreground">
+              Version 1 will be released by 1st September.
+            </p>
+
+            <motion.div
               className="mt-16 opacity-60"
               initial={{ opacity: 0 }}
               animate={{ opacity: 0.6 }}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -90,5 +91,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [tailwindcssAnimate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- display planned 1st September release on landing page
- replace remaining `any` and empty interfaces for lint compliance
- switch Tailwind plugin to ESM import

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b0adbe033c8322b69e6c2f4f843fa9